### PR TITLE
Clarify thunk structure, handle error

### DIFF
--- a/redux/async.md
+++ b/redux/async.md
@@ -13,23 +13,28 @@ store.dispatch(findImages('dragon')).then(() =>
 )
 ```
 
-Here `findImages` is just an action creator, but a slightly fancy one:
+Here `findImages` is just an action creator, but a slightly fancy one (let's assume we're using [Superagent](https://github.com/visionmedia/superagent) to make the API call):
 
 ```js
-function findImages(searchterm) {
-
+function findImages (searchterm) {
   return (dispatch) => {
     dispatch(requestImages(searchterm))
 
-    return request.get(`https://api.instagram.com/v1/tags/search?q=${searchterm}`)
-      .then(response => response.json())
-      .then(json => dispatch(receiveImages(subreddit, json)))
+    request
+      .get(`https://api.instagram.com/v1/tags/search?q=${searchterm}`)
+      .end((err, res) => {
+        if (err) {
+          return dispatch(retrievalError(err))
+        }
+        dispatch(receiveImages(searchterm, res.body)))
+      })
   }
 }
 ```
 
 Some key ideas from this:
 
-- We track progress of Async calls using normal actions and state
-- The function returned by the action creator is handled by thunk middleware
-- We return a promise we can do fancy stuff later
+- We track progress of async calls using normal actions.
+- We can call dispatch more than once during the process.
+  - For example, we could display a loading spinner when the `REQUEST_IMAGES` action is dispatched.
+- The function returned by the action creator is handled by thunk middleware (which takes care of providing the `dispatch` parameter, and `getState` is also available if required).

--- a/redux/async.md
+++ b/redux/async.md
@@ -1,19 +1,22 @@
-The docs provide an excellent introduction on how to write asynchronous operations in the context of Redux.
+The [Redux docs](http://redux.js.org/docs/advanced/AsyncActions.html) provide an excellent introduction on how to write asynchronous operations in the context of Redux.
 
-http://redux.js.org/docs/advanced/AsyncActions.html
+We can dispatch async actions like this:
 
-> **Useful context** : on Reddit, a sub-forum is called a _subreddit_  e.g. www.reddit.com/r/NewZealand is a subreddit all about NZ, www.reddit.com/r/frontend is a subreddit about frontend dev.
+```jsx
+import {connect} from 'react-redux'
 
-The solution leads you to dispatching actions like this:
-
-```js
-store.dispatch(findImages('dragon')).then(() =>
-  // 
-  console.log(store.getState())
+let ShowImages = ({dispatch}) => (
+  <button
+    onClick={() => dispatch(findImages('wombats'))}>
+    Show wombat pics</button>
 )
+
+// Use react-redux to hook up the component to redux.
+// This will make `dispatch` available to the component as a prop.
+ShowImages = connect()(ShowImages)
 ```
 
-Here `findImages` is just an action creator, but a slightly fancy one (let's assume we're using [Superagent](https://github.com/visionmedia/superagent) to make the API call):
+Here `findImages` is just an action creator, but a slightly fancy one. Let's assume we're using [Superagent](https://github.com/visionmedia/superagent) to make the API call:
 
 ```js
 function findImages (searchterm) {


### PR DESCRIPTION
The previous sample code was a bit confusing, hitting Instagram but having a `subreddit` argument. It also looked as if it would use Superagent, which doesn't support `.then` out of the box (though there's a promise wrapper available).

This PR rewrites the example to dispatch an error action, and use an ordinary Superagent call. It adds a little detail in the accompanying text.
